### PR TITLE
Update to Rules and Regulations (2.1.8) and (2.7.4)

### DIFF
--- a/Bylaws_and_Regulations_of_WPI_Lens_and_Lights.tex
+++ b/Bylaws_and_Regulations_of_WPI_Lens_and_Lights.tex
@@ -278,6 +278,7 @@ These regulations are adopted by the Executive Board or the Club to supplement t
 \item The person who obtains the keys from an officer will be responsible for their use until they are returned to that officer.
 \item Key use must obey all policies set forward by WPI, including that keys may not be taken more than 1 mile from campus. If an officer is leaving campus, they must secure their keys in the lockbox.
 \item Misuse of the keys or negligence by a member may be cause for the Executive Board to take disciplinary action.
+\item If an officer is involved with an organization that is actively renting items from Lens and Lights, said officer must lock their officer key ring in the lock box for the duration of the rental period.
 
 \end{enumerate}
 
@@ -360,6 +361,7 @@ Active members may borrow equipment under the following conditions:
 \item Lens and Lights is not a rental house. Events have always been and will remain first priority for the club. The decision to rent equipment rests solely with the LNL Executive Board, and rentals will only be approved when the Executive Board can be assured that the equipment will be used by trained personnel.
 \item Events are given priority over rentals. Equipment that is required for an event is not available to rent.
 \item When equipment is rented, the renter will be required to sign a contract agreeing to pay for the repair or replacement of any damaged or lost equipment.
+\item The Vice President or their designee must give approval for additional items to be rented following the original rental load out. Under no condition may items be taken without prior approval being granted. Any item taken without permission may be recalled at the discretion of the Executive Board.
 
 \end{enumerate}
 


### PR DESCRIPTION
Changes to the Rules and Regulations as follows: 
(2.1.8) If an officer is involved with an organization that is actively renting items from Lens and Lights, said officer must lock their officer key ring in the lock box for the duration of the rental period.

(2.7.4) The Vice President or their designee must give approval for additional items to be rented following the original rental load out. Under no condition may items be taken without prior approval being granted. Any item taken without permission may be recalled at the discretion of the Executive Board.