### PR TITLE
Remove "DRAFT" watermark

### DIFF
--- a/Bylaws_and_Regulations_of_WPI_Lens_and_Lights.tex
+++ b/Bylaws_and_Regulations_of_WPI_Lens_and_Lights.tex
@@ -3,7 +3,6 @@
 \usepackage[utf8]{inputenc}
 \usepackage{hyperref}
 \usepackage{cleveref}
-\usepackage{draftwatermark}
 
 \crefformat{chapter}{\S#2#1#3}
 \crefformat{section}{\S#2#1#3} % see manual of cleveref, section 8.2.1


### PR DESCRIPTION
When the bylaws are compiled now in LaTeX there is a watermark added stating "DRAFT" from when amendments were being proposed. This should be removed now as the copy of the Bylaws here is the one currently recognized by the club.